### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Statemachine in PHP 5.3
 #### Gitter
 [![Gitter chat](https://badges.gitter.im/Metabor/Statemachine.png)](https://gitter.im/Metabor/Statemachine)
 
-### Continous Integration/Deployment
+### Continuous Integration/Deployment
 
 #### TravisCI
 [![Build Status](http://img.shields.io/travis/Metabor/Statemachine.svg)](https://travis-ci.org/Metabor/Statemachine)


### PR DESCRIPTION
@Metabor, I've corrected a typographical error in the documentation of the [Statemachine](https://github.com/Metabor/Statemachine) project. Specifically, I've changed continous to continuous. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.