### PR TITLE
Made the event and state name from the Exception accessible.

### DIFF
--- a/src/Metabor/Statemachine/Exception/WrongEventForStateException.php
+++ b/src/Metabor/Statemachine/Exception/WrongEventForStateException.php
@@ -5,6 +5,20 @@ namespace Metabor\Statemachine\Exception;
 class WrongEventForStateException extends \RuntimeException
 {
     /**
+     * The event that was triggered.
+     *
+     * @var string
+     */
+    protected $eventName;
+
+    /**
+     * The subject's current state.
+     *
+     * @var string
+     */
+    protected $stateName;
+
+    /**
      * @param string     $stateName
      * @param string     $eventName
      * @param int        $code
@@ -12,7 +26,20 @@ class WrongEventForStateException extends \RuntimeException
      */
     public function __construct($stateName, $eventName, $code = 0, \Exception $previous = null)
     {
+        $this->stateName = $stateName;
+        $this->eventName = $eventName;
+
         $message = 'Current state "' . $stateName . '" doesn\'t have event "' . $eventName . '"';
         parent::__construct($message, $code, $previous);
+    }
+
+    public function getEventName()
+    {
+        return $this->eventName;
+    }
+
+    public function getStateName()
+    {
+        return $this->stateName;
     }
 }

--- a/tests/Metabor/Statemachine/Exception/WrongEventForStateExceptionTest.php
+++ b/tests/Metabor/Statemachine/Exception/WrongEventForStateExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Metabor\Statemachine\Exception;
+
+class WrongEventForStateExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStateNameIsAccessible()
+    {
+        $exception = new WrongEventForStateException('stateName', 'eventName', 0);
+
+        $this->assertSame('stateName', $exception->getStateName());
+    }
+
+    public function testEventNameIsAccessible()
+    {
+        $exception = new WrongEventForStateException('stateName', 'eventName', 0);
+
+        $this->assertSame('eventName', $exception->getEventName());
+    }
+}


### PR DESCRIPTION
This change makes the state name and event name accessible from the exception so one can use them to display custom error messages rather than the default message from a `WrongEventForStateException`.